### PR TITLE
Støtter behandlingsnummer i header til kall mot PDL for hentPerson og hentPersonBolk

### DIFF
--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/behandling/Behandling.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/behandling/Behandling.kt
@@ -1,0 +1,40 @@
+package no.nav.siftilgangskontroll.core.behandling
+
+/**
+ * Enum som representerer forskjellige behandlingstyper for å administrere ytelseskrav.
+ * Denne klassen brukes for å håndtere retten til ulike ytelser ved ulike hendelser som bortfall av
+ * arbeidsinntekt for yrkesaktive relatert til barns eller barnepassers sykdom, barns funksjonshemning,
+ * og pleie av nærstående i livets sluttfase.
+ */
+enum class Behandling(val behandlingsnummer: String) {
+
+    /**
+     * Behandlingstype for saksbehandling av søknader og refusjonskrav om pleiepenger for syke barn
+     * etter folketrygdloven kap. 9.
+     *
+     * @see <a href="https://behandlingskatalog.intern.nav.no/process/purpose/PLEIE_OMSORGS_OG_OPPLAERINGSPENGER/daa46292-de92-4924-9f60-2490b29d0c30">NAV Behandlingskatalog</a>
+     */
+    PLEIEPENGER_SYKT_BARN("B249"),
+
+    /**
+     * Behandlingstype for saksbehandling av søknader og refusjonskrav om pleiepenger i livets sluttfase
+     * etter folketrygdloven kap. 9.
+     *
+     * @see <a href="https://behandlingskatalog.intern.nav.no/process/purpose/PLEIE_OMSORGS_OG_OPPLAERINGSPENGER/e2630d73-2013-4654-bc6e-e08281b1167e">NAV Behandlingskatalog</a>
+     */
+    PLEIEPENGER_I_LIVETS_SLUTTFASE("B566"),
+
+    /**
+     * Behandlingstype for saksbehandling av personopplysninger relatert til omsorgspenger fra bruker.
+     *
+     * @see <a href="https://behandlingskatalog.intern.nav.no/process/purpose/PLEIE_OMSORGS_OG_OPPLAERINGSPENGER/d0f205b9-01cc-437d-9528-9aaf65931ba0">NAV Behandlingskatalog</a>
+     */
+    OMSORGSPENGERUTBETALING("B135"),
+
+    /**
+     * Behandlingstype for saksbehandling av søknader om flere omsorgsdager og meldinger om deling av omsorgsdager.
+     *
+     * @see <a href="https://behandlingskatalog.intern.nav.no/process/purpose/PLEIE_OMSORGS_OG_OPPLAERINGSPENGER/4a1c9324-9c5e-4ddb-ac7f-c55d1dcd9736">NAV Behandlingskatalog</a>
+     */
+    OMSORGSPENGER_RAMMEMELDING("B142")
+}

--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/BarnContext.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/BarnContext.kt
@@ -2,6 +2,7 @@ package no.nav.siftilgangskontroll.core.pdl
 
 import kotlinx.coroutines.runBlocking
 import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.siftilgangskontroll.core.behandling.Behandling
 import no.nav.siftilgangskontroll.core.tilgang.BarnTilgangForespørsel
 import no.nav.siftilgangskontroll.pdl.generated.ID
 import no.nav.siftilgangskontroll.pdl.generated.hentbarn.Person
@@ -13,10 +14,11 @@ typealias BarnIdent = String
 data class PdlBarn(
     private val pdlService: PdlService,
     private val callId: String,
+    private val behandling: Behandling,
     val barnIdent: List<ID>,
-    val systemToken: String
+    val systemToken: String,
 ) {
-    val barn = runBlocking { pdlService.barn(barnIdent, systemToken, callId) }
+    val barn = runBlocking { pdlService.barn(barnIdent, systemToken, callId, behandling) }
 
     fun harAdresseSkjerming(ident: BarnIdent): Boolean = barn
         .filtererPåIdent(ident)
@@ -41,19 +43,22 @@ internal data class BarnContext(
     val pdlService: PdlService,
     private val callId: String,
     private val bearerToken: JwtToken,
-    private val systemtoken: JwtToken
+    private val systemtoken: JwtToken,
+    private val behandling: Behandling
 ) {
     val pdlPersonContext = PdlPersonContext(
         pdlService = pdlService,
         borgerToken = bearerToken.tokenAsString,
-        callId = callId
+        callId = callId,
+        behandling = behandling
     )
 
     val pdlBarn = PdlBarn(
         pdlService = pdlService,
         barnIdent = barnTilgangForespørsel.barnIdenter,
         callId = callId,
-        systemToken = systemtoken.tokenAsString
+        systemToken = systemtoken.tokenAsString,
+        behandling = behandling
     )
 }
 

--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
@@ -2,6 +2,7 @@ package no.nav.siftilgangskontroll.core.pdl
 
 import kotlinx.coroutines.runBlocking
 import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.siftilgangskontroll.core.behandling.Behandling
 import no.nav.siftilgangskontroll.core.utils.personIdent
 import no.nav.siftilgangskontroll.pdl.generated.hentperson.ForelderBarnRelasjon
 import no.nav.siftilgangskontroll.pdl.generated.hentperson.Person
@@ -12,11 +13,12 @@ const val MYNDIG_ALDER = 18
 
 data class PdlPersonContext(
     private val pdlService: PdlService,
+    private val behandling: Behandling,
     val borgerToken: String,
-    val callId: String
+    val callId: String,
 ) {
     val person: Person = runBlocking {
-        val person = pdlService.person(JwtToken(borgerToken).personIdent(), borgerToken, callId)
+        val person = pdlService.person(JwtToken(borgerToken).personIdent(), borgerToken, callId, behandling)
         person.copy(forelderBarnRelasjon = person.forelderBarnRelasjon.filterNot { it.relatertPersonsIdent == null })
     }
 

--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/tilgang/TilgangService.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/tilgang/TilgangService.kt
@@ -1,6 +1,7 @@
 package no.nav.siftilgangskontroll.core.tilgang
 
 import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.siftilgangskontroll.core.behandling.Behandling
 import no.nav.siftilgangskontroll.core.pdl.*
 import no.nav.siftilgangskontroll.core.pdl.BarnContext
 import no.nav.siftilgangskontroll.policy.spesification.evaluate
@@ -46,7 +47,8 @@ class TilgangService(
         barnTilgangForespørsel: BarnTilgangForespørsel,
         bearerToken: String,
         systemToken: String,
-        callId: String = UUID.randomUUID().toString()
+        callId: String = UUID.randomUUID().toString(),
+        behandling: Behandling
     ): List<TilgangResponseBarn> {
 
         val barnContext = BarnContext(
@@ -54,7 +56,8 @@ class TilgangService(
             pdlService = pdlService,
             bearerToken = JwtToken(bearerToken),
             systemtoken = JwtToken(systemToken),
-            callId = callId
+            callId = callId,
+            behandling = behandling
         )
 
         return barnContext.pdlBarn.barn.map { barn ->
@@ -87,11 +90,12 @@ class TilgangService(
      *
      * @return TilgangResponsePerson: 'data' er null dersom det ikke gitt tilgang. Se 'policyEvaulation' for begrunnelse.
      */
-    fun hentPerson(bearerToken: String, callId: String = UUID.randomUUID().toString()): TilgangResponsePerson {
+    fun hentPerson(bearerToken: String, callId: String = UUID.randomUUID().toString(), behandling: Behandling): TilgangResponsePerson {
         val personContext = PdlPersonContext(
             pdlService = pdlService,
             borgerToken = bearerToken,
-            callId = callId
+            callId = callId,
+            behandling = behandling
         )
         return evaluate(
             ctx = personContext,

--- a/src/main/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangsController.kt
+++ b/src/main/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangsController.kt
@@ -7,6 +7,7 @@ import no.nav.siftilgangskontroll.Routes.BARN
 import no.nav.siftilgangskontroll.Routes.IDENTER
 import no.nav.siftilgangskontroll.Routes.PERSON
 import no.nav.siftilgangskontroll.Routes.TILGANG
+import no.nav.siftilgangskontroll.core.behandling.Behandling
 import no.nav.siftilgangskontroll.core.pdl.AktørId
 import no.nav.siftilgangskontroll.core.tilgang.*
 import no.nav.siftilgangskontroll.policy.spesification.PolicyDecision
@@ -38,7 +39,9 @@ class TilgangsController(
     @ResponseStatus(OK)
     fun hentTilgangTilPerson(): ResponseEntity<TilgangResponsePerson> {
         val personOppslagRespons = tilgangService.hentPerson(
-            bearerToken = pdlAuthService.borgerToken(), callId = "sif-tilgangskontroll-${UUID.randomUUID()}"
+            behandling = Behandling.PLEIEPENGER_SYKT_BARN,
+            bearerToken = pdlAuthService.borgerToken(),
+            callId = "sif-tilgangskontroll-${UUID.randomUUID()}"
         )
         logger.info("Hentet tilgang: {}", personOppslagRespons)
 
@@ -53,6 +56,7 @@ class TilgangsController(
             barnTilgangForespørsel = barnTilgangForespørsel,
             bearerToken = pdlAuthService.borgerToken(),
             systemToken = pdlAuthService.systemToken(),
+            behandling = Behandling.PLEIEPENGER_SYKT_BARN,
             callId = "sif-tilgangskontroll-${UUID.randomUUID()}"
         )
         logger.info("Hentet tilgang: {}", barnOppslagRespons)

--- a/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlStubs.kt
+++ b/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlStubs.kt
@@ -6,10 +6,15 @@ import no.nav.siftilgangskontroll.core.pdl.utils.PdlOperasjon
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
 
-internal fun WireMockServer.stubPdlRequest(pdlOperasjon: PdlOperasjon, responseBody: () -> String) {
+internal fun WireMockServer.stubPdlRequest(pdlOperasjon: PdlOperasjon, medbehandlingsnummer: Boolean = true, responseBody: () -> String) {
+    val mappingBuilder = WireMock.post(WireMock.urlPathMatching("/pdl-api-mock/graphql"))
+        .withHeader("Authorization", WireMock.matching(".*"))
+    if (medbehandlingsnummer) {
+        mappingBuilder.withHeader("Behandlingsnummer", WireMock.matching(".*"))
+    }
+
     stubFor(
-        WireMock.post(WireMock.urlPathMatching("/pdl-api-mock/graphql"))
-            .withHeader("Authorization", WireMock.matching(".*"))
+        mappingBuilder
             .withRequestBody(WireMock.containing(pdlOperasjon.navn))
             .willReturn(
                 WireMock.aResponse()


### PR DESCRIPTION
Bakgrunn for dette er at PDL ønsker å utføre tilgangskontroll på hvilket opplysninger man har hjemmel til å innhente. Disse opplysningene er gjerne dokumentert i et av de Behandlingene i Behandlingskatalogen.

Bruk av behandlingsnummer brukes primært på kall til hentPerson og hentPersonBolk der der er flere opplysningsfelt. Kall for HentIdenter sjekker ikke brukerrettigheter og det er ikke nødvendig med behandlingsnummer.