### PR TITLE
Utleder myndighetsalder fra fødselsår.

### DIFF
--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/BarnContext.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/BarnContext.kt
@@ -31,9 +31,13 @@ data class PdlBarn(
     fun fødselsdato(ident: BarnIdent): LocalDate = barn
         .filtererPåIdent(ident)
         .fødselsdato()
+    fun fødselsÅr(ident: BarnIdent): Int = barn
+        .filtererPåIdent(ident)
+        .fødselsÅr()
 
     fun erMyndig(ident: BarnIdent): Boolean {
-        val alder = Period.between(fødselsdato(ident), LocalDate.now()).years
+        val nåværendeÅr = LocalDate.now().year
+        val alder = nåværendeÅr - fødselsÅr(ident)
         return alder >= MYNDIG_ALDER
     }
 }
@@ -70,6 +74,7 @@ fun Person.harAdresseSkjerming(): Boolean = adressebeskyttelse.isNotEmpty()
 
 fun Person.erDød(): Boolean = doedsfall.isNotEmpty()
 fun Person.fødselsdato(): LocalDate = LocalDate.parse(foedsel.first().foedselsdato!!)
+fun Person.fødselsÅr(): Int = foedsel.first().foedselsaar!!
 
 fun List<Person>.filtererPåIdent(ident: BarnIdent) =
     first { it.folkeregisteridentifikator.first().identifikasjonsnummer == ident }

--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
@@ -25,8 +25,10 @@ data class PdlPersonContext(
     fun erDød(): Boolean = person.erDød()
     fun relasjoner(): List<ForelderBarnRelasjon> = person.forelderBarnRelasjon
     fun fødselsdato(): LocalDate = LocalDate.parse(person.foedsel.first().foedselsdato!!)
+    fun fødselsÅr(): Int = person.foedsel.first().foedselsaar!!
     fun erMyndig(): Boolean {
-        val alder = Period.between(fødselsdato(), LocalDate.now()).years
+        val nåværendeÅr = LocalDate.now().year
+        val alder = nåværendeÅr - fødselsÅr()
 
         return alder >= MYNDIG_ALDER
     }

--- a/core/src/main/resources/pdl/hentBarn.graphql
+++ b/core/src/main/resources/pdl/hentBarn.graphql
@@ -12,6 +12,7 @@ query($identer: [ID!]!) {
             },
             foedsel {
                 foedselsdato
+                foedselsaar
             }
             doedsfall {
                 doedsdato

--- a/core/src/main/resources/pdl/hentPerson.graphql
+++ b/core/src/main/resources/pdl/hentPerson.graphql
@@ -11,6 +11,7 @@ query($ident: ID!){
         }
         foedsel {
             foedselsdato
+            foedselsaar
         }
         adressebeskyttelse {
             gradering

--- a/src/test/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangServiceTest.kt
@@ -128,7 +128,7 @@ class TilgangServiceTest {
                 personBolk = listOf(
                     defaultHentPersonBolkResult(
                         folkeregisteridentifikator = BarnFolkeregisteridentifikator(relatertPersonsIdent),
-                        fødselsdato = BarnFødsel("2002-01-01")
+                        fødselsdato = BarnFødsel(foedselsdato = "2002-01-01", foedselsaar = 2002)
                     )
                 )
             )
@@ -266,9 +266,10 @@ class TilgangServiceTest {
     fun `gitt NAV-bruker er under myndighetsalder (18), forvent nektet tilgang`() {
 
         wireMockServer.stubPdlRequest(PdlOperasjon.HENT_PERSON) {
+            val fødselsdato = LocalDate.now().minusYears(17)
             pdlHentPersonResponse(
                 person = defaultHentPersonResult(
-                    fødselsdato = Foedsel(LocalDate.now().minusYears(17).toString())
+                    foedsel = Foedsel(fødselsdato.toString(), fødselsdato.year)
                 )
             )
         }

--- a/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlResponses.kt
+++ b/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlResponses.kt
@@ -14,7 +14,7 @@ import no.nav.siftilgangskontroll.pdl.generated.hentbarn.Person as Barn
 
 object PdlResponses {
     fun defaultHentPersonResult(
-        fødselsdato: Foedsel = Foedsel("1990-09-27"),
+        foedsel: Foedsel = Foedsel(foedselsdato = "1990-09-27", foedselsaar = 1990),
         navn: Navn = Navn(
             fornavn = "Ole",
             mellomnavn = null,
@@ -26,7 +26,7 @@ object PdlResponses {
         relatertPersonsIdent: String? = "123"
     ) = Person(
         folkeregisteridentifikator = listOf(Folkeregisteridentifikator("123456789")),
-        foedsel = listOf(fødselsdato),
+        foedsel = listOf(foedsel),
         navn = listOf(navn),
         doedsfall = dødsdato?.let { listOf(it) } ?: listOf(),
         adressebeskyttelse = adressebeskyttelse?.let { listOf(it) } ?: listOf(),
@@ -41,7 +41,7 @@ object PdlResponses {
 
     fun defaultHentPersonBolkResult(
         folkeregisteridentifikator: BarnFolkeregisteridentifikator = BarnFolkeregisteridentifikator("123"),
-        fødselsdato: BarnFoedsel = BarnFoedsel("2020-01-01"),
+        fødselsdato: BarnFoedsel = BarnFoedsel(foedselsdato = "2020-01-01", foedselsaar = 2020),
         navn: BarnNavn = BarnNavn(
             fornavn = "Dole",
             mellomnavn = null,


### PR DESCRIPTION
Fødselsdato kan være av variende kvalitet der noen personer kan ha fiktive fødselsdatoer. Dette gjelder spesielt personer som ikke er født i Norge og de med fødselsdato migrert fra det gamle folkeregisteret (DSF).

Bruker derfor fødselsår da dette er obligatorisk i Freg og PDL, mens fødselsdato ikke er det.