### PR TITLE
Revert "Utleder myndig alder fra fødselsår. (#160)"

### DIFF
--- a/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
+++ b/core/src/main/kotlin/no/nav/siftilgangskontroll/core/pdl/PdlPersonContext.kt
@@ -25,10 +25,8 @@ data class PdlPersonContext(
     fun erDød(): Boolean = person.erDød()
     fun relasjoner(): List<ForelderBarnRelasjon> = person.forelderBarnRelasjon
     fun fødselsdato(): LocalDate = LocalDate.parse(person.foedselsdato.first().foedselsdato!!)
-    fun fødselsÅr(): Int = person.foedselsdato.first().foedselsaar!!
     fun erMyndig(): Boolean {
-        val nåværendeÅr = LocalDate.now().year
-        val alder = nåværendeÅr - fødselsÅr()
+        val alder = Period.between(fødselsdato(), LocalDate.now()).years
 
         return alder >= MYNDIG_ALDER
     }

--- a/core/src/main/resources/pdl/hentBarn.graphql
+++ b/core/src/main/resources/pdl/hentBarn.graphql
@@ -11,7 +11,6 @@ query($identer: [ID!]!) {
             },
             foedselsdato {
                 foedselsdato
-                foedselsaar
             }
             doedsfall {
                 doedsdato

--- a/core/src/main/resources/pdl/hentPerson.graphql
+++ b/core/src/main/resources/pdl/hentPerson.graphql
@@ -10,7 +10,6 @@ query($ident: ID!){
         }
         foedselsdato {
             foedselsdato
-            foedselsaar
         }
         adressebeskyttelse {
             gradering

--- a/src/test/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/siftilgangskontroll/tilgang/TilgangServiceTest.kt
@@ -130,7 +130,7 @@ class TilgangServiceTest {
                 personBolk = listOf(
                     defaultHentPersonBolkResult(
                         folkeregisteridentifikator = BarnFolkeregisteridentifikator(relatertPersonsIdent),
-                        fødselsdato = BarnFødsel(foedselsdato = "2002-01-01", foedselsaar = 2002)
+                        fødselsdato = BarnFødsel("2002-01-01")
                     )
                 )
             )
@@ -268,10 +268,9 @@ class TilgangServiceTest {
     fun `gitt NAV-bruker er under myndighetsalder (18), forvent nektet tilgang`() {
 
         wireMockServer.stubPdlRequest(PdlOperasjon.HENT_PERSON) {
-            val fødselsdato = LocalDate.now().minusYears(17)
             pdlHentPersonResponse(
                 person = defaultHentPersonResult(
-                    foedsel = Foedselsdato(fødselsdato.toString(), fødselsdato.year)
+                    foedselsdato = Foedselsdato(LocalDate.now().minusYears(17).toString())
                 )
             )
         }
@@ -336,7 +335,7 @@ class TilgangServiceTest {
                 personBolk = listOf(
                     defaultHentPersonBolkResult(
                         folkeregisteridentifikator = BarnFolkeregisteridentifikator(relatertPersonsIdent),
-                        fødselsdato = BarnFødsel(foedselsdato = "2002-01-01", foedselsaar = 2002)
+                        fødselsdato = BarnFødsel(foedselsdato = "2002-01-01")
                     )
                 )
             )

--- a/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlResponses.kt
+++ b/src/test/kotlin/no/nav/siftilgangskontroll/wiremock/PdlResponses.kt
@@ -15,7 +15,7 @@ import no.nav.siftilgangskontroll.pdl.generated.hentbarn.Person as Barn
 object PdlResponses {
     fun defaultHentPersonResult(
         ident: String = "123456789",
-        foedsel: Foedselsdato = Foedselsdato(foedselsdato = "1990-09-27", foedselsaar = 1990),
+        foedselsdato: Foedselsdato = Foedselsdato(foedselsdato = "1990-09-27"),
         navn: Navn = Navn(
             fornavn = "Ole",
             mellomnavn = null,
@@ -26,7 +26,7 @@ object PdlResponses {
         relatertPersonsIdent: String? = "123"
     ) = Person(
         folkeregisteridentifikator = listOf(Folkeregisteridentifikator(ident)),
-        foedselsdato = listOf(foedsel),
+        foedselsdato = listOf(foedselsdato),
         navn = listOf(navn),
         doedsfall = dødsdato?.let { listOf(it) } ?: listOf(),
         adressebeskyttelse = adressebeskyttelse?.let { listOf(it) } ?: listOf(),
@@ -41,7 +41,7 @@ object PdlResponses {
 
     fun defaultHentPersonBolkResult(
         folkeregisteridentifikator: BarnFolkeregisteridentifikator = BarnFolkeregisteridentifikator("123"),
-        fødselsdato: BarnFoedsel = BarnFoedsel(foedselsdato = "2020-01-01", foedselsaar = 2020),
+        fødselsdato: BarnFoedsel = BarnFoedsel("2020-01-01"),
         navn: BarnNavn = BarnNavn(
             fornavn = "Dole",
             mellomnavn = null,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Krav om myndig alder fungerer ikke som forventet når vi kun sjekker alders år.
Vi skal ikke tillate søkere under 18 år. Med eksisterende sjekk tillates det hvis de fyller 18 i inneværende år.

### **Løsning**
Reverter https://github.com/navikt/sif-tilgangskontroll/commit/a0f0548410d28bb1be8c0aa2cd12f21f2cc3787a slik at vi bruker fødselsdato til denne sjekken.

Vi forventer at fødsesldato alltid er satt da vi bruker det til tilgangsstyring, selvom kvaliteten kan variere (som forklart [her](https://pdl-docs.ansatt.nav.no/ekstern/index.html#_f%C3%B8dselsdato)). Hvis den mangler vil oppslaget feile.
